### PR TITLE
Avoid .shape on uncast input

### DIFF
--- a/lassonet/interfaces.py
+++ b/lassonet/interfaces.py
@@ -481,7 +481,7 @@ class BaseLassoNet(BaseEstimator, metaclass=ABCMeta):
                 patience=self.patience_path,
                 return_state_dict=return_state_dicts,
             )
-            if is_dense and self.model.selected_count() < X.shape[1]:
+            if is_dense and self.model.selected_count() < X_train.shape[1]:
                 is_dense = False
                 if current_lambda / lambda_start < 2:
                     warnings.warn(


### PR DESCRIPTION
Hi! Love the library and we're finding it super useful. Just a tiny bugfix - the `BaseLassoNet` interface at one point does `.shape` on the _uncast_ `X` input, which works for most input types (Pandas DataFrame, NumPy array, PyTorch tensor) but not necessarily arbitrary inputs (which is causing an issue for our particular subclass... but also just seems to be a bug in general). This is a simple fix that does it on the cast version, as is done everywhere else in the code.