### PR TITLE
Adding pandas to install list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "matplotlib",
         "sortedcontainers",
         "tqdm",
+        "pandas",
     ],
     tests_require=["pytest"],
     python_requires=">=3.8",


### PR DESCRIPTION
adding pandas to the install list.  It is required by \examples\miceprotein.py